### PR TITLE
Changes to library semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ val = 'b'
 
 with switch(val) as s:
     a = s.case('a', process_a)  # -> None
-    b = s.case('b', lambda: process_with_data(val, num, 'other values still'))  # -> "found with data"
+    b = s.case('b', process_with_data)  # -> "found with data"
     c = s.default(process_any)  # -> None
 
 
 with switch(val, fall_through=True) as s:
     a = s.case('a', process_a)  # -> None
-    b = s.case('b', lambda: process_with_data(val, num, 'other values still'))  # -> "found with data"
+    b = s.case('b', process_with_data)  # -> "found with data"
 
     c = s.case(lambda val: isinstance(val, str), lambda: "matched on predicate")  # -> "matched on predicate"
 

--- a/README.md
+++ b/README.md
@@ -15,18 +15,29 @@ num = 7
 val = input("Enter a key. a, b, c or any other: ")
 
 with switch(val) as s:
-    s.case('a', process_a)
-    s.case('b', lambda: process_with_data(val, num, 'other values still'))
-    s.default(process_any)
+    a = s.case('a', process_a)  # -> "a found"
+    b = s.case('b', lambda: process_with_data(val, num, 'other values still'))  # -> None
+    c = s.default(process_any)  # -> None
+
+with switch(val, fall_through=True) as s:
+    a = s.case('a', process_a)  # -> "a found"
+    b = s.case('b', lambda: process_with_data(val, num, 'other values still'))  # -> "found with data"
+    
+    c = s.case(lambda val: isinstance(val, str), lambda: "matched on predicate")  # -> "matched on predicate"
+    
+    d = s.default(process_any)  # -> None
+
     
 def process_a():
     print("Found A!")
+    return "a found"
     
 def process_any():
     print("Found Default!")
     
 def process_with_data(*value):
     print("Found with data: {}".format(value))
+    return "found with data"
 ``` 
 
 ## Features
@@ -34,10 +45,8 @@ def process_with_data(*value):
 * More explicit than using dictionaries with functions as values.
 * Verifies the signatures of the methods
 * Supports default case
-* Checks for duplicate keys / cases
-* Keys can be anything hashable (numbers, strings, objects, etc.)
 * Could be extended for "fall-through" cases (doesn't yet)
-* Use range and list for multiple cases mapped to a single action
+* Able to dispatch based on predicate functions as well as values
 
 ## Multiple cases, one action
 
@@ -51,26 +60,7 @@ with switch(value) as s:
     s.case([1, 3, 5, 7], lambda: ...)
     s.case([0, 2, 4, 6, 8], lambda: ...)
     s.default(lambda: ...)
-```
-
-```python
-# with ranges:
-value = 4  # matches first case
-
-with switch(value) as s:
-    s.case(range(1, 6), lambda: ...)
-    s.case(range(6, 7), lambda: ...)
-    s.default(lambda: ...)
-```
-
-## Closed vs. Open ranges
-
-Looking at the above code it's a bit weird that 6 appears 
-at the end of one case, beginning of the next. But `range()` is
-half open/closed. 
-
-To handle the inclusive case, I've added closed_range(start, stop).
-For example, `closed_range(1,5)` -> `[1,2,3,4,5]` 
+``` 
 
 ## Why not just raw `dict`?
 
@@ -97,17 +87,24 @@ while True:
     action = get_action(action)
 
     with switch(action) as s:
-        s.case(['c', 'a'], create_account)
-        s.case('l', log_into_account)
-        s.case('r', register_cage)
-        s.case('u', update_availability)
-        s.case(['v', 'b'], view_bookings)
-        s.case('x', exit_app)
-        s.case('', lambda: None)
-        s.case(range(1,6), lambda: set_level(action))
-        s.default(unknown_command)
+        
+        cases = (
+            s.case(['c', 'a'], create_account)
+            s.case('l', log_into_account)
+            s.case('r', register_cage)
+            s.case('u', update_availability)
+            s.case(['v', 'b'], view_bookings)
+            s.case('x', exit_app)
+            s.case('', lambda: None)
+            s.case(range(1,6), lambda: set_level(action))
+            s.default(unknown_command)
+        )
+        
+        if any(cases):
+            result, *_ = (case for case in cases if case)
+        else:
+            result = None
     
-    result = s.result
 ```
 
 Now compare that to they espoused *pythonic* way:

--- a/README.md
+++ b/README.md
@@ -10,34 +10,36 @@ way to define execution blocks: the `with` statement.
 
 ```python
 from switchlang import switch
+from typing import Optional
+
+
+def process_a():
+    return "found a"
+
+
+def process_any():
+    return "found default"
+
+
+def process_with_data(*value):
+    return "found with data"
+
 
 num = 7
 val = input("Enter a key. a, b, c or any other: ")
 
 with switch(val) as s:
-    a = s.case('a', process_a)  # -> "a found"
-    b = s.case('b', lambda: process_with_data(val, num, 'other values still'))  # -> None
-    c = s.default(process_any)  # -> None
+    a = s.case('a', process_a)  # -> Optional["found a"]
+    b = s.case('b', lambda: process_with_data(val, num, 'other values still'))  # -> Optional["found with data"]
+    c = s.default(process_any)  # -> Optional["found default"]
 
 with switch(val, fall_through=True) as s:
-    a = s.case('a', process_a)  # -> "a found"
-    b = s.case('b', lambda: process_with_data(val, num, 'other values still'))  # -> "found with data"
-    
-    c = s.case(lambda val: isinstance(val, str), lambda: "matched on predicate")  # -> "matched on predicate"
-    
-    d = s.default(process_any)  # -> None
+    a = s.case('a', process_a)  # -> Optional["found a"]
+    b = s.case('b', lambda: process_with_data(val, num, 'other values still'))  # -> Optional["found with data"]
 
-    
-def process_a():
-    print("Found A!")
-    return "a found"
-    
-def process_any():
-    print("Found Default!")
-    
-def process_with_data(*value):
-    print("Found with data: {}".format(value))
-    return "found with data"
+    c = s.case(lambda val: isinstance(val, str), lambda: "matched on predicate")  # -> "matched on predicate"
+
+    d = s.default(process_any)  # -> "found default"
 ``` 
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ way to define execution blocks: the `with` statement.
 
 ```python
 from switchlang import switch
-from typing import Optional
 
 
 def process_a():
@@ -26,16 +25,17 @@ def process_with_data(*value):
 
 
 num = 7
-val = input("Enter a key. a, b, c or any other: ")
+val = 'b'
 
 with switch(val) as s:
-    a = s.case('a', process_a)  # -> Optional["found a"]
-    b = s.case('b', lambda: process_with_data(val, num, 'other values still'))  # -> Optional["found with data"]
-    c = s.default(process_any)  # -> Optional["found default"]
+    a = s.case('a', process_a)  # -> None
+    b = s.case('b', lambda: process_with_data(val, num, 'other values still'))  # -> "found with data"
+    c = s.default(process_any)  # -> None
+
 
 with switch(val, fall_through=True) as s:
-    a = s.case('a', process_a)  # -> Optional["found a"]
-    b = s.case('b', lambda: process_with_data(val, num, 'other values still'))  # -> Optional["found with data"]
+    a = s.case('a', process_a)  # -> None
+    b = s.case('b', lambda: process_with_data(val, num, 'other values still'))  # -> "found with data"
 
     c = s.case(lambda val: isinstance(val, str), lambda: "matched on predicate")  # -> "matched on predicate"
 

--- a/switchlang.py
+++ b/switchlang.py
@@ -66,11 +66,9 @@ class switch:
         if key == self.value:  # check to see if the key matches self.value
             self.called = True
             return func()
-        elif callable(key):  # the key is a predicate, check to see if it evaluates to True on key(self.value)
-            result = key(self.value)
-            if result:
-                self.called = True
-                return func()
+        elif callable(key) and key(self.value):  # the key is a predicate function
+            self.called = True
+            return func()
 
     def default(self, func: Callable[[], Any]) -> None:
         """

--- a/switchlang.py
+++ b/switchlang.py
@@ -1,38 +1,92 @@
 # Here is a first pass implementation at adding switch
 import uuid
-from typing import Callable, Any, List
+import collections.abc as abc
+from typing import Callable, Any, Optional
 
 
 class switch:
-    __no_result = uuid.uuid4()
+    """
+    A context-manager acting as an implementation of a switch statement.
+    """
+    def __init__(self, value, fall_through=False):
+        """
+        Initialize switch context manager.
 
-    def __init__(self, value):
+        Args:
+            value: The value we dispatch on
+            fall_through: If false, do not execute cases after the first case is matched
+
+        i.e.
+
+        meaning_of_life = 42
+        with switch(42, fall_through=False) as s:
+            s.case(42, lambda: print('hello, world') # this will execute
+            s.case([42, 0], lambda: None) # this will NOT execute
+
+        with switch(42, fall_through=True) as s:
+            s.case(42, lambda: print('hello, world') # this will execute
+            s.case([42, 0], lambda: None) # this WILL execute
+        """
         self.value = value
-        self.cases = {}
-        self.__result = switch.__no_result
+        self.fall_through = fall_through
+        self.called = False  # flag that determines if any pattern was matched prior to default
 
-    def default(self, func: Callable[[], Any]):
-        self.case('__default__', func)
+    def case(self, key, func: Callable[[], Any]) -> Optional[Any]:
+        """
+        Determine if the key matches self.value and return the result of the function if so.
 
-    def case(self, key, func: Callable[[], Any]):
-        if isinstance(key, range):
-            for n in key:
-                self.case(n, func)
-            return
+        If match is found, set self.called to True and return func() else None
 
-        if isinstance(key, list):
-            for i in key:
-                self.case(i, func)
-            return
+        Args:
+            key: The values to dispatch on
+            func: The function to call on self.value
 
-        if key in self.cases:
-            raise ValueError("Duplicate case: {}".format(key))
-        if not func:
-            raise ValueError("Action for case cannot be None.")
+        Returns: func() or None
+
+        """
+        # handle instances where a match has been found already and we don't want to fall through
+        if not self.fall_through and self.called:
+            return None
+
         if not callable(func):
             raise ValueError("Func must be callable.")
 
-        self.cases[key] = func
+        if isinstance(key, abc.Mapping):
+            raise ValueError('You cannot dispatch on a mapping')
+        elif isinstance(key, abc.Iterable) and not isinstance(key, str):
+            if self.value in key: # match on values
+                self.called = True
+                return func()
+            else:  # match on predicates
+                predicates = (f for f in key if callable(f))
+                if any(p(self.value) for p in predicates):
+                    self.called = True
+                    return func()
+
+        if key == self.value:  # check to see if the key matches self.value
+            self.called = True
+            return func()
+        elif callable(key):  # the key is a predicate, check to see if it evaluates to True on key(self.value)
+            result = key(self.value)
+            if result:
+                self.called = True
+                return func()
+
+    def default(self, func: Callable[[], Any]) -> None:
+        """
+        Set the default function to be called if argument not matched.
+        Args:
+            func: Callable
+
+        Returns: None
+
+        """
+        if not self.fall_through and self.called:
+            return None
+
+        self.called = True
+        return func()
+
 
     def __enter__(self):
         return self
@@ -40,28 +94,6 @@ class switch:
     def __exit__(self, exc_type, exc_val, exc_tb):
         if exc_val:
             raise exc_val
-
-        func = self.cases.get(self.value)
-        if not func:
-            func = self.cases.get('__default__')
-
-        if not func:
+        elif not self.called:
             raise Exception("Value does not match any case and there "
                             "is no default case: value {}".format(self.value))
-
-        # noinspection PyCallingNonCallable
-        self.__result = func()
-
-    @property
-    def result(self):
-        if self.__result == switch.__no_result:
-            raise Exception("No result has been computed (did you access switch.result inside the with block?)")
-
-        return self.__result
-
-
-def closed_range(start: int, stop: int, step=1) -> range:
-    if start >= stop:
-        raise ValueError("Start must be less than stop.")
-
-    return range(start, stop+step, step)

--- a/tests/coretests.py
+++ b/tests/coretests.py
@@ -1,5 +1,5 @@
 import unittest
-from switchlang import switch, closed_range
+from switchlang import switch
 
 
 # here is a custom type we can use as a key for our tests
@@ -8,124 +8,49 @@ class TestKeyObject:
 
 
 class CoreTests(unittest.TestCase):
-    def test_has_matched_case_int(self):
+    def test_has_matched_value_no_fallthrough(self):
         value = 7
         with switch(value) as s:
-            s.case(1, lambda: "one")
-            s.case(5, lambda: "five")
-            s.case(7, lambda: "seven")
-            s.default(lambda: 'default')
+            a = s.case(7, lambda: "seven")
+            b = s.case(5, lambda: "five")
+            c = s.default(lambda: 'default')
 
-        self.assertEqual(s.result, "seven")
+        self.assertEqual(a, "seven")
+        self.assertEqual(b, None)
+        self.assertEqual(c, None)
 
-    def test_has_matched_case_object(self):
-        t1 = TestKeyObject()
-        t2 = TestKeyObject()
-        t3 = TestKeyObject()
+    def test_has_matched_value_fallthrough(self):
+        value = 7
+        with switch(value, fall_through=True) as s:
+            a = s.case(7, lambda: "seven")
+            b = s.case(5, lambda: "five")
+            c = s.case((7, 81), lambda: "matched")
+            d = s.default(lambda: 'default')
 
-        with switch(t2) as s:
-            s.case(t1, lambda: t1)
-            s.case(t2, lambda: t2)
-            s.case(t3, lambda: t3)
-            s.default(lambda: None)
+        self.assertEqual(a, "seven")
+        self.assertEqual(b, None)
+        self.assertEqual(c, "matched")
+        self.assertEqual(d, "default")
 
-        self.assertEqual(s.result, t2)
+    def test_match_on_predicate(self):
+        value = 7
+        with switch(value, fall_through=True) as s:
+            a = s.case(lambda n: n < 10, lambda: "less than 10")
+            b = s.case(lambda n: isinstance(n, int), lambda: "is integer")
+            c = s.case(lambda n: False, lambda: "False")
 
-    def test_default_passthrough(self):
-        value = 11
+        self.assertEqual(a, "less than 10")
+        self.assertEqual(b, "is integer")
+        self.assertEqual(c, None)
+
+    def test_match_on_predicate_in_iterable_key(self):
+        value = 7
         with switch(value) as s:
-            s.case(1, lambda: '1')
-            s.case(2, lambda: '2')
-            s.default(lambda: 'default')
+            a = s.case(('foo', lambda n: n < 10, lambda n: False), lambda: "bar")
 
-        self.assertEqual(s.result, "default")
+        self.assertEqual(a, "bar")
 
-    def test_none_as_valid_case(self):
-        with switch(None) as s:
-            s.case(1, lambda: 'one')
-            s.case(None, lambda: 'none')
-            s.default(lambda: "default")
-
-        self.assertEqual(s.result, 'none')
-
-    def test_error_no_match_no_default(self):
-        with self.assertRaises(Exception):
-            with switch('val') as s:
-                s.case(1, lambda: None)
-                s.case(2, lambda: None)
-
-    def test_error_duplicate_case(self):
+    def test_dictionary_key_raises_value_error(self):
         with self.assertRaises(ValueError):
-            with switch('val') as s:
-                s.case(1, lambda: None)
-                s.case(1, lambda: None)
-
-    def test_multiple_values_one_case_range(self):
-        for value in range(1, 5):
-            with switch(value) as s:
-                s.case(range(1, 6), lambda: "1-to-5")
-                s.case(range(6, 7), lambda: "6")
-                s.default(lambda: 'default')
-
-            self.assertEqual(s.result, "1-to-5")
-
-        for value in range(6, 7):
-            with switch(value) as s:
-                s.case(range(1, 6), lambda: "1-to-5")
-                s.case(range(6, 7), lambda: "6")
-                s.default(lambda: 'default')
-
-            self.assertEqual(s.result, "6")
-
-        with switch(7) as s:
-            s.case(range(1, 6), lambda: "1-to-5")
-            s.case(range(6, 7), lambda: "6")
-            s.default(lambda: 'default')
-
-        self.assertEqual(s.result, "default")
-
-    def test_multiple_values_one_case_list(self):
-        with switch(6) as s:
-            s.case([1, 3, 5, 7], lambda: "odd")
-            s.case([0, 2, 4, 6, 8], lambda: "even")
-            s.default(lambda: 'default')
-
-        self.assertEqual(s.result, "even")
-
-    def test_return_value_from_case(self):
-        value = 4
-        with switch(value) as s:
-            s.case([1, 3, 5, 7], lambda: value + 1)
-            s.case([0, 2, 4, 6, 8], lambda: value * value)
-            s.default(lambda: 0)
-
-        self.assertEqual(s.result, 16)
-
-    # noinspection PyStatementEffect
-    def test_result_inaccessible_if_hasnt_run(self):
-        with self.assertRaises(Exception):
-            s = switch(7)
-            s.result
-
-    def test_closed_range(self):
-        for value in [1, 2, 3, 4, 5]:
-            with switch(value) as s:
-                s.case(closed_range(1, 5), lambda: "1-to-5")
-                s.case(closed_range(6, 7), lambda: "6")
-                s.default(lambda: 'default')
-
-            self.assertEqual(s.result, "1-to-5")
-
-        with switch(0) as s:
-            s.case(closed_range(1, 5), lambda: "1-to-5")
-            s.case(closed_range(6, 7), lambda: "6")
-            s.default(lambda: 'default')
-
-        self.assertEqual(s.result, "default")
-
-        with switch(6) as s:
-            s.case(closed_range(1, 5), lambda: "1-to-5")
-            s.case(closed_range(6, 7), lambda: "6")
-            s.default(lambda: 'default')
-
-        self.assertEqual(s.result, "6")
+            with switch(7) as s:
+                s.case({'hello': 'world'}, lambda: True)


### PR DESCRIPTION
Though I honestly think [functools.singledispatch](https://docs.python.org/3/library/functools.html#functools.singledispatch) and `if/elif/else` statements are much better for this kind of behavior, I made a few changes to the library and documentation so as to make it (hopefully) a bit more functional

## Switching

I made two large changes to the library

1. The `switch` class now has a `self.fall_through` flag that can be set on instantiation as well as a `self.called` flag that is set to True once a match has been found
2. cases are now evaluated based on whether `switch_instance.fall_through == True && switch_instance.called == True`. This makes it able to return values from cases as well as use functions that evaluate to `True` or `False` as possible switch conditions

This way, we don't need to keep a mapping of values and functions on which to dispatch. Also, it doesn't prevent one from using it the way, you, @mikeckennedy initially intended with the exception that return values are specific to each case and not the instance of switch itself

```python
meaning_of_life = 42

with switch(42, fall_through=False) as s:
    s.case(42, lambda: print('hello, world') # this will execute
    s.case([42, 0], lambda: None) # this will NOT execute
    
with switch(42, fall_through=True) as s:
    s.case(42, lambda: print('hello, world') # this will execute
    s.case([42, 0], lambda: None) # this WILL execute

    # the following line would be difficult to replicate as the library is currently written
    # one would need to reference the variable as nonlocal or global in the
    # function passed to s.case and using a lambda would not be possible

    less_than_50 = s.case(lambda n: n < 50, lambda: True) # this will execute

assert less_than_50 == True
```